### PR TITLE
Fix name prop Link component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 
 # dependencies
 node_modules/
+package-lock.json
 
 # logs
 npm-debug.log*

--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -1,6 +1,6 @@
 ---
-const { className, href, external, title } = Astro.props
-const anchorProps = external ? { target: '_blank', rel: 'noopener' } : {}
+const { className, href, isExternal, title } = Astro.props
+const anchorProps = isExternal ? { target: '_blank', rel: 'noopener' } : {}
 ---
 
 <a class={`${className} relative font-extrabold text-xl transition text-primary hover:text-white`} href={href} {...anchorProps}>


### PR DESCRIPTION
Fix Link component prop name using 'external' when it's actually 'isExternal', causing links to open in the same browser tab