### PR TITLE
Set Stars background fixed

### DIFF
--- a/src/components/Starfield.astro
+++ b/src/components/Starfield.astro
@@ -7,7 +7,7 @@ const { subtle } = Astro.props as Props;
 
 <div class:list={[
   'pointer-events-none bg-black',
-  'absolute inset-0 -z-50',
+  'fixed inset-0 -z-50',
   subtle && 'bg-[length:100%_175%]'
 ]}>
     <div class='starfield absolute inset-0' />


### PR DESCRIPTION
Hola midu, este pull request tiene como objetivo modificar la configuración del parametro del position de fondo de estrellas para que al hacer scroll down se quede estático y no se pierda.

Modificación:

src > components > Starfield.astro: en el class list del div se cambió la clase de tailwind de absolute a fixed

Cualquier cosa quedo atento.
Saludos.

PD: gracias por el contenido a la comunidad