### PR TITLE
Add responsive for 1280px screens

### DIFF
--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -6,7 +6,7 @@ const anchorProps = isExternal ? { target: '_blank', rel: 'noopener' } : {}
 <a class={`
 	${className}
 	${disabled ? 'text-white' : ''}
-	group relative py-3 leading-tight font-extrabold text-2xl transition text-primary hover:text-white`
+	group relative py-3 leading-tight font-extrabold text-2xl transition text-primary hover:text-white xl:text-xl`
 }
 href={disabled ? '#' : href}
 {...anchorProps}>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -31,7 +31,7 @@ const NAVIGATION_LINKS = [{
 }]
 ---
 
-<aside class='flex flex-col items-center lg:sticky top-24'>
+<aside class='flex flex-col items-center lg:sticky top-24 xl:top-10 xl:sticky'>
 	<Logo />
 	<nav class='mt-24 text-center'>
 		<ul class='flex flex-col gap-y-8 mb-20'>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,7 +27,7 @@ const { title } = Astro.props;
 	<body>
 		<Background />
 
-		<div class='pt-24 flex justify-between m-auto gap-x-24 w-[1200px]'>
+		<div class='pt-24 flex justify-between m-auto gap-x-24 w-[1200px] xl:pt-10'>
 			<div class='w-52'>
 				<Navigation />
 			</div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/69129445/215185748-7e2e77ca-972b-44bb-9ad5-3630fb43d743.png)

* The margins were changed to and the navigation text size adapt them to 1280 px screens 

Now:
![image](https://user-images.githubusercontent.com/69129445/215185976-41b491ce-edac-4c45-9f49-f5bce7eed024.png)
