### PR TITLE
Change keepcoding sponsor url

### DIFF
--- a/src/components/sections/Sponsors.astro
+++ b/src/components/sections/Sponsors.astro
@@ -9,7 +9,7 @@ import SectionTitle from '@components/SectionTitle.astro';
 
 		<div class='grid grid-cols-4 md:grid-cols-4 w-full gap-4 justify-center items-center mt-10'>
 		<PatrocinadorBox img='dondominio.webp' href='https://dondominio.com' />
-		<PatrocinadorBox img='keepcoding.webp' href='https://keepcoding.com' />
+		<PatrocinadorBox img='keepcoding.webp' href='https://keepcoding.io' />
 		</div>
 
 	<!-- <div class='grid grid-cols-4 md:grid-cols-4 w-full gap-4 mb-4 justify-center items-center'>


### PR DESCRIPTION
URL del sponsor de keepcoding no funciona, porque en vez de keepcoding.com es keepcoding.io

![Screenshot 2024-05-27 at 2 19 51 PM](https://github.com/midudev/midufest/assets/54672897/e93962a4-daea-4b27-91c5-c81feb56fbde)

![Screenshot 2024-05-27 at 2 19 43 PM](https://github.com/midudev/midufest/assets/54672897/af5854ec-abc0-433d-ad21-0612d2938aa1)
