### PR TITLE
fix: remove e from Keychron.

### DIFF
--- a/src/components/sections/Agenda.astro
+++ b/src/components/sections/Agenda.astro
@@ -42,7 +42,7 @@ const DAY_ONE = [
 	},
 	{
 		time: 1716919500000,
-		title: 'Sorteo teclado Keychrone',
+		title: 'Sorteo teclado Keychron',
 		speaker: 'Miguel Ángel Durán'
 	},
 	{


### PR DESCRIPTION
It has a typographical error, the Keychron brand name is without the final e.